### PR TITLE
Set logUserId, logRequestContext, logProcessContext

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -141,7 +141,12 @@ public class Driver {
      *
      * @return CompletionStage which is completed when all required requests to the Openshift complete.
      */
-    public CompletionStage<EnvironmentCreateResponse> create(EnvironmentCreateRequest environmentCreateRequest) {
+    public CompletionStage<EnvironmentCreateResponse> create(
+            EnvironmentCreateRequest environmentCreateRequest,
+            Optional<String> logUserId,
+            Optional<String> logRequestContext,
+            Optional<String> logProcessContext) {
+
         if (lifecycle.isShuttingDown()) {
             throw new StoppingException();
         }
@@ -169,6 +174,10 @@ public class Driver {
         environmentVariables.put("containerPort", configuration.getBuildAgentContainerPort());
         environmentVariables.put("buildContentId", environmentCreateRequest.getRepositoryBuildContentId());
         environmentVariables.put("accessToken", rawWebToken);
+
+        logUserId.ifPresent(userId -> environmentVariables.put("logUserId", userId));
+        logRequestContext.ifPresent(requestContext -> environmentVariables.put("logRequestContext", requestContext));
+        logProcessContext.ifPresent(processContext -> environmentVariables.put("logProcessContext", processContext));
 
         try {
             environmentVariables.putAll(mdcToMap());

--- a/src/main/java/org/jboss/pnc/environmentdriver/endpoints/Public.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/endpoints/Public.java
@@ -18,11 +18,13 @@
 
 package org.jboss.pnc.environmentdriver.endpoints;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -61,9 +63,17 @@ public class Public {
     @Authenticated
     @POST
     @Path("/create")
-    public CompletionStage<EnvironmentCreateResponse> create(EnvironmentCreateRequest environmentCreateRequest) {
+    public CompletionStage<EnvironmentCreateResponse> create(
+            @HeaderParam("log-user-id") String logUserId,
+            @HeaderParam("log-request-context") String logRequestContext,
+            @HeaderParam("log-process-context") String logProcessContext,
+            EnvironmentCreateRequest environmentCreateRequest) {
         logger.info("Requested new environment: {}", environmentCreateRequest.getEnvironmentLabel());
-        return driver.create(environmentCreateRequest);
+        return driver.create(
+                environmentCreateRequest,
+                Optional.ofNullable(logUserId),
+                Optional.ofNullable(logRequestContext),
+                Optional.ofNullable(logProcessContext));
     }
 
     /**


### PR DESCRIPTION
Read the 'log-user-id', 'log-request-context', and 'log-process-context'
headers from requests (if present) and use them to sent environment
variables during creation of builder images.