### PR TITLE
[NCL-6792] No need to specify environment-label for ssh service

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,8 +123,6 @@ environment-driver:
       apiVersion: v1
       metadata:
         name: "%{ssh-service-name}"
-        labels:
-          environment: "%{environment-label}"
       spec:
         ports:
           - name: 2222-ssh


### PR DESCRIPTION
The environment-label is also not injected into the ssh service template
during creation.