### PR TITLE
Fix env variable names which now use the name from headers

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,10 +113,10 @@ environment-driver:
                 value: "%{workerUserPassword}"
               - name: accessToken
                 value: "%{accessToken}"
-              - name: logUserId
-                value: "%{logUserId}"
-              - name: logProcessContext
-                value: "%{logProcessContext}"
+              - name: log-user-id
+                value: "%{log-user-id}"
+              - name: log-process-context
+                value: "%{log-process-context}"
               - name: buildContentId
                 value: "%{buildContentId}"
               - name: buildAgentArguments
@@ -247,10 +247,10 @@ environment-driver:
                   value: "%{workerUserPassword}"
                 - name: accessToken
                   value: "%{accessToken}"
-                - name: logUserId
-                  value: "%{logUserId}"
-                - name: logProcessContext
-                  value: "%{logProcessContext}"
+                - name: log-user-id
+                  value: "%{log-user-id}"
+                - name: log-process-context
+                  value: "%{log-process-context}"
                 - name: buildContentId
                   value: "%{buildContentId}"
                 - name: buildAgentArguments


### PR DESCRIPTION
@thescouser89 @matejonnet Hi, in https://github.com/project-ncl/environment-driver/blob/main/src/main/java/org/jboss/pnc/environmentdriver/Driver.java#L176 the environment variables set from the headers have different names, so I believe we need to adjust them in the templates.