### PR TITLE
[NCL-6801] - Handle early failures when requesting pod or services

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/BadResourcesRequestException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/BadResourcesRequestException.java
@@ -1,0 +1,14 @@
+package org.jboss.pnc.environmentdriver.exceptions;
+
+public class BadResourcesRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = 4098171178739096610L;
+
+    public BadResourcesRequestException(String message) {
+        super(message);
+    }
+
+    public BadResourcesRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/DriverException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/DriverException.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.environmentdriver;
+package org.jboss.pnc.environmentdriver.exceptions;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/FailedResponseException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/FailedResponseException.java
@@ -1,4 +1,4 @@
-package org.jboss.pnc.environmentdriver;
+package org.jboss.pnc.environmentdriver.exceptions;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/QuotaExceededException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/QuotaExceededException.java
@@ -1,0 +1,14 @@
+package org.jboss.pnc.environmentdriver.exceptions;
+
+public class QuotaExceededException extends RuntimeException {
+
+    private static final long serialVersionUID = 351111124411290766L;
+
+    public QuotaExceededException(String message) {
+        super(message);
+    }
+
+    public QuotaExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/StoppingException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/StoppingException.java
@@ -1,4 +1,4 @@
-package org.jboss.pnc.environmentdriver;
+package org.jboss.pnc.environmentdriver.exceptions;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/UnableToRequestResourcesException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/UnableToRequestResourcesException.java
@@ -1,0 +1,10 @@
+package org.jboss.pnc.environmentdriver.exceptions;
+
+public class UnableToRequestResourcesException extends RuntimeException {
+
+    private static final long serialVersionUID = -5726573303690333295L;
+
+    public UnableToRequestResourcesException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/UnableToStartException.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/UnableToStartException.java
@@ -1,4 +1,4 @@
-package org.jboss.pnc.environmentdriver;
+package org.jboss.pnc.environmentdriver.exceptions;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/BadResourcesRequestExceptionMapper.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/BadResourcesRequestExceptionMapper.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.environmentdriver.exceptions.mappers;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.pnc.api.dto.ErrorResponse;
+import org.jboss.pnc.environmentdriver.exceptions.BadResourcesRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class BadResourcesRequestExceptionMapper implements ExceptionMapper<BadResourcesRequestException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BadResourcesRequestExceptionMapper.class);
+
+    @Override
+    public Response toResponse(BadResourcesRequestException e) {
+        logger.error("An exception occurred while parsing either the service or the pod templates", e);
+
+        Response.ResponseBuilder builder = Response.status(Response.Status.BAD_REQUEST.getStatusCode());
+        builder.entity(new ErrorResponse(e)).type(MediaType.APPLICATION_JSON);
+
+        return builder.build();
+    }
+
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/DefaultExceptionMapper.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/DefaultExceptionMapper.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.environmentdriver.runtime;
+package org.jboss.pnc.environmentdriver.exceptions.mappers;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/QuotaExceededExceptionMapper.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/QuotaExceededExceptionMapper.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.environmentdriver.exceptions.mappers;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.pnc.api.dto.ErrorResponse;
+import org.jboss.pnc.environmentdriver.exceptions.QuotaExceededException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class QuotaExceededExceptionMapper implements ExceptionMapper<QuotaExceededException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuotaExceededExceptionMapper.class);
+
+    @Override
+    public Response toResponse(QuotaExceededException e) {
+        logger.error("An exception occurred due to exceeded quota", e);
+
+        Response.ResponseBuilder builder = Response.status(Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
+        builder.entity(new ErrorResponse(e)).type(MediaType.APPLICATION_JSON);
+
+        return builder.build();
+    }
+
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/StoppingExceptionMapper.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/StoppingExceptionMapper.java
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.environmentdriver.runtime;
+package org.jboss.pnc.environmentdriver.exceptions.mappers;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.jboss.pnc.environmentdriver.StoppingException;
+import org.jboss.pnc.environmentdriver.exceptions.StoppingException;
 
 /**
  * @author Matej Lazar &lt;mlazar@redhat.com&gt;

--- a/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/UnableToRequestResourcesExceptionMapper.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/exceptions/mappers/UnableToRequestResourcesExceptionMapper.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.environmentdriver.exceptions.mappers;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.pnc.api.dto.ErrorResponse;
+import org.jboss.pnc.environmentdriver.exceptions.UnableToRequestResourcesException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class UnableToRequestResourcesExceptionMapper implements ExceptionMapper<UnableToRequestResourcesException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(UnableToRequestResourcesExceptionMapper.class);
+
+    @Override
+    public Response toResponse(UnableToRequestResourcesException e) {
+        logger.error("An exception occurred while requesting resources", e);
+
+        Response.ResponseBuilder builder = Response.status(Response.Status.BAD_REQUEST.getStatusCode());
+        builder.entity(new ErrorResponse(e)).type(MediaType.APPLICATION_JSON);
+
+        return builder.build();
+    }
+
+}

--- a/src/test/java/org/jboss/pnc/environmentdriver/DriverTest.java
+++ b/src/test/java/org/jboss/pnc/environmentdriver/DriverTest.java
@@ -191,23 +191,7 @@ public class DriverTest {
                     .when()
                     .post("/create")
                     .then()
-                    .statusCode(200);
-
-            Request callback = callbackRequests.take();
-            logger.info("Request callback: {}", callback);
-
-            EnvironmentCreateResult creationCompleted = mapper
-                    .convertValue(callback.getAttachment(), EnvironmentCreateResult.class);
-            logger.info("Environment creation completed with status: {}", creationCompleted.getStatus());
-            Assertions.assertEquals(
-                    ResultStatus.FAILED,
-                    creationCompleted.getStatus(),
-                    "Unexpected environment creation status.");
-
-            Assertions.assertEquals(
-                    creationCompleted.getMessage(),
-                    Driver.ERROR_MESSAGE_INTRO + Driver.ERROR_MESSAGE_TEMPLATE_PARSE,
-                    "Unexpected environment creation message");
+                    .statusCode(400);
         } finally {
             System.setProperty("environment-driver.openshift.pod", originalPod);
         }


### PR DESCRIPTION
When requesting a pod with a very high quota, the podRequest fail with a message like 

> 14:55:35,600 ERROR [org.jbo.pnc.env.run.DefaultExceptionMapper] (executor-thread-29) An exception occurred when processing REST response: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://172.27.0.1/api/v1/namespaces/newcastle-devel-builders/pods. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. pods "pnc-ba-pod-anq7ln47oeaaa-40715d" is forbidden: exceeded quota: newcastle-devel-builders-quota, requested: limits.memory=95Gi, used: limits.memory=2000Mi, limited: limits.memory=96Gi.

which however does not prevent the startMonitor to execute. Same kind of error can happen if the yaml podTemplate or the yaml serviceTemplate are bogus and cannot be parsed.

This PR tries to fail early in the process, preventing the startMonitor to execute if the previous stages produce any kind of exception.

@matejonnet could you  please review :-) Thanks!