### PR TITLE
Improve log when checking if pod is running

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -618,7 +618,7 @@ public class Driver {
                 .onRetry(
                         // Received the DriverException
                         ctx -> userLogger.warn(
-                                "Running pod {} check #{}; Last error: [{}].",
+                                "Running pod {} check #{}; last checked status: [{}].",
                                 podName,
                                 ctx.getAttemptCount(),
                                 ctx.getLastFailure() != null ? ctx.getLastFailure().getMessage() : ""))


### PR DESCRIPTION
@matejonnet Change the log because it looks like the checks are errors, but they are not