### PR TITLE
[NCL-7047] - Configure timeouts when creating environments

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Configuration.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Configuration.java
@@ -161,4 +161,10 @@ public class Configuration {
     @ConfigProperty(name = "environment-driver.callback-retry-max-delay-msec", defaultValue = "5000")
     long callbackRetryMaxDelayMsec;
 
+    @ConfigProperty(name = "environment-driver.openshift-client.connect-timeout-msec", defaultValue = "10000")
+    int openshiftClientConnectTimeoutMsec;
+
+    @ConfigProperty(name = "environment-driver.openshift-client.request-timeout-msec", defaultValue = "10000")
+    int openshiftClientRequestTimeoutMsec;
+
 }

--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -191,6 +191,9 @@ public class Driver {
             return CompletableFuture.failedFuture(e);
         }
 
+        openShiftClient.getConfiguration().setConnectionTimeout(configuration.getOpenshiftClientConnectTimeoutMsec());
+        openShiftClient.getConfiguration().setRequestTimeout(configuration.getOpenshiftClientRequestTimeoutMsec());
+
         podTemplateProperties.put(
                 "resourcesMemory",
                 builderPodMemory(configuration.getBuilderPodMemory(), environmentCreateRequest.getPodMemoryOverride()));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,9 @@ environment-driver:
   service-running-retry-max-delay-msec: 5000
   callback-retry-delay-msec: 500
   callback-retry-max-delay-msec: 5000
+  openshift-client:
+    connect-timeout-msec: 30000
+    request-timeout-msec: 30000
   openshift:
     ssh-service-port-name: 2222-ssh
     pod: |


### PR DESCRIPTION
Configure timeouts to avoid "Frequent Socket Timeout Exception when creating environment" logs