### PR TITLE
Set log level of Openshift resource request failure to warn

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -554,9 +554,9 @@ public class Driver {
             msg += String
                     .format("Pod %s requested resources: %.2fGB %.1fcpu; ", podName, memoryUsedByPod, cpuUsedByPod);
         } catch (KubernetesClientException kEx) {
-            logger.error("Cannot calculate Pod {} requested resources", podName);
+            logger.warn("Cannot calculate Pod {} requested resources", podName, kEx);
         } catch (RuntimeException rEx) {
-            logger.error("Cannot convert Pod {} requested resources", podName);
+            logger.warn("Cannot convert Pod {} requested resources", podName, rEx);
         }
 
         try {
@@ -565,11 +565,11 @@ public class Driver {
 
             msg += String.format("Available resources: %.2fGB %.1fcpu", availableMemory, availableCpu);
         } catch (KubernetesClientException kEx) {
-            logger.error("Cannot calculate available resources in the namespace of Pod {}", podName);
+            logger.warn("Cannot calculate available resources in the namespace of Pod {}", podName, kEx);
         } catch (RuntimeException rEx) {
-            logger.error("Cannot convert available resources in the namespace of Pod {}", podName);
+            logger.warn("Cannot convert available resources in the namespace of Pod {}", podName, rEx);
         } catch (Exception ex) {
-            logger.error("Error while getting available resources in the namespace of Pod {}", podName);
+            logger.warn("Error while getting available resources in the namespace of Pod {}", podName, ex);
         }
 
         return msg;


### PR DESCRIPTION
The `getPodRequestedVsAvailableResourcesInfo` method is used to return a
String of the requested and available resources for the pod. The
returned string is used on failure to run a pod after we have reached
the maximum retries.

This commit sets the logging message when we fail to get the requested
and available resources in that method to `warn` rather than `error`
since those logs do not flag a critical error in environment-driver that
needs further investigation.