### PR TITLE
[NCL-6585] - Set the build.config.id environment variable to empty if…

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -196,6 +196,8 @@ public class Driver {
 
         if (configuration.isSidecarArchiveEnabled()) {
             podTemplateProperties.put(ARCHIVAL_SERVICE_BUILD_CONFIG_ID, environmentCreateRequest.getBuildConfigId());
+        } else {
+            podTemplateProperties.put(ARCHIVAL_SERVICE_BUILD_CONFIG_ID, "");
         }
 
         try {


### PR DESCRIPTION
… archival service is not enabled