### PR TITLE
[NCL-6598] - Add archival enabled configuration back to the Environme…

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/Driver.java
@@ -520,8 +520,11 @@ public class Driver {
                             gaugeMetric.ifPresent(g -> g.incrementMetric(METRICS_POD_STARTED_FAILED_KEY));
                         }
                     } else {
-                        EnvironmentCreateResult environmentCreateResult = EnvironmentCreateResult
-                                .success(serviceUriWithContext, configuration.getWorkingDirectory(), sshPassword);
+                        EnvironmentCreateResult environmentCreateResult = EnvironmentCreateResult.success(
+                                serviceUriWithContext,
+                                configuration.getWorkingDirectory(),
+                                sshPassword,
+                                configuration.isSidecarArchiveEnabled());
                         callback = callback(completionCallback, environmentCreateResult);
                         gaugeMetric.ifPresent(g -> g.incrementMetric(METRICS_POD_STARTED_SUCCESS_KEY));
                     }


### PR DESCRIPTION
…ntCreateResult, so it can be used later in the BPM process