### PR TITLE
[NCL-7614] Set graceful shutdown to 30 seconds

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 quarkus:
   shutdown:
-    timeout: 300
+    timeout: 30
   log:
     category:
       "org.jboss.pnc":


### PR DESCRIPTION
By default, if the pod has not stopped 30 seconds [1] after it got the SIGTERM signal, the pod is SIGKILled.

We should allow a graceful shutdown of 30 seconds on Quarkus as a result.