### PR TITLE
[NCL-8098] Specify roles for env-driver endpoints

### DIFF
--- a/src/main/java/org/jboss/pnc/environmentdriver/endpoints/Public.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/endpoints/Public.java
@@ -22,11 +22,11 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
-import io.quarkus.security.Authenticated;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.pnc.api.dto.ComponentVersion;
 import org.jboss.pnc.api.environmentdriver.dto.EnvironmentCompleteRequest;
@@ -60,7 +60,7 @@ public class Public {
      * Create new build environment for a given configuration. EnvironmentId which is created based on
      * {@link EnvironmentCreateRequest#getEnvironmentLabel()} is returned.
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-environment-driver-admin", "pnc-users-admin" })
     @POST
     @Path("/create")
     public CompletionStage<EnvironmentCreateResponse> create(EnvironmentCreateRequest environmentCreateRequest) {
@@ -73,7 +73,7 @@ public class Public {
      * connection to the environment.
      *
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-environment-driver-admin", "pnc-users-admin" })
     @PUT
     @Path("/complete")
     public CompletionStage<EnvironmentCompleteResponse> complete(
@@ -99,7 +99,7 @@ public class Public {
      * The complete request have to hit the same service instance as create to cancel potentially active create
      * operations.
      */
-    @Authenticated
+    @RolesAllowed({ "pnc-users-environment-driver-admin", "pnc-users-admin" })
     @PUT
     @Path("/cancel/{environmentId}")
     public EnvironmentCompleteResponse cancel(@PathParam("environmentId") String environmentId) {


### PR DESCRIPTION
As part of the Authorization work, we need to restrict who can access the environment-driver endpoints that could cause catastrophic situations.

With that in mind, the 2 roles we allow users to do stuff is:

- pnc-users-environment-driver-admin: service accounts that need to talk to environment-driver
- pnc-users-admin: pnc developers that will have "god" permissions