### PR TITLE
[NCL-8182] Access a token from Indy for the builder pod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,10 @@
       <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
     <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-mutiny</artifactId>
     </dependency>

--- a/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyService.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyService.java
@@ -1,0 +1,51 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.environmentdriver.clients;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Indy service representing the Indy server. It uses Quarkus magical rest client to generate the client implementation
+ */
+@RegisterRestClient(configKey = "indy-service")
+public interface IndyService {
+
+    /**
+     * Ask Indy to give us the token that we will use for Maven communication with Indy, in the builder pod for the
+     * particular buildId
+     *
+     * @param indyTokenRequestDTO the DTO to send to Indy
+     * @param accessToken accessToken required to send data. Note that it should include "Bearer <token>"
+     *
+     * @return Token DTO
+     */
+    @Path("/api/security/token")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    public IndyTokenResponseDTO getAuthToken(
+            IndyTokenRequestDTO indyTokenRequestDTO,
+            @HeaderParam("Authorization") String accessToken);
+}

--- a/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyTokenRequestDTO.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyTokenRequestDTO.java
@@ -15,36 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.jboss.pnc.environmentdriver.clients;
 
-package org.jboss.pnc.environmentdriver;
-
-import io.quarkus.test.Mock;
-import org.eclipse.microprofile.jwt.JsonWebToken;
-
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
 
 /**
- * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ * DTO of the Indy token endpoint request
  */
-@Mock
-public class JsonWebTokenMock implements JsonWebToken {
-    @Override
-    public String getName() {
-        return null;
-    }
+@Jacksonized
+@Builder
+@Data
+@AllArgsConstructor
+public class IndyTokenRequestDTO {
 
-    @Override
-    public Set<String> getClaimNames() {
-        return null;
-    }
-
-    @Override
-    public <T> T getClaim(String claimName) {
-        return null;
-    }
-
-    @Override
-    public String getRawToken() {
-        return "-raw-auth-token-";
-    }
+    @JsonProperty("build-id")
+    private String buildId;
 }

--- a/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyTokenResponseDTO.java
+++ b/src/main/java/org/jboss/pnc/environmentdriver/clients/IndyTokenResponseDTO.java
@@ -1,0 +1,35 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.environmentdriver.clients;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * DTO of the Indy token endpoint response
+ */
+@Jacksonized
+@Builder
+@Data
+@AllArgsConstructor
+public class IndyTokenResponseDTO {
+
+    private String token;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,7 +40,9 @@ quarkus:
     client-id: service-account
     credentials:
       secret: secret-of-service-account
-
+  rest-client:
+    indy-service:
+      url: "http://localhost:8080"
   opentelemetry:
     enabled: true
     tracer:


### PR DESCRIPTION
With the migration to an OIDC server with a short token span, we cannot reuse the user token for the builder-pod when used with Maven since the token will expire quickly, and Maven has no understanding on how to renew an OIDC user token.

Instead, we'll use a token generated by Indy that can only be used by Maven for a particular build-id. That token duration will last for the duration of the build.